### PR TITLE
Document Keys

### DIFF
--- a/src/keys.h
+++ b/src/keys.h
@@ -5,304 +5,311 @@
 extern "C" {
 #endif
 
+/**
+ * @defgroup keys Controller
+ * @{
+ * Controller functions in OSLib.
+ */
 
-/** @defgroup keys Controller
-
-	Controller functions in OSLib.
-	@{
-*/
-
-/** List of keys. */
-typedef union		{
-	struct		{
-		int select:1;					//!< Select
-		int reserved1:2;				//!< For padding, do not use
-		int start:1;					//!< Start
-		int up:1;						//!< Up (d-pad)
-		int right:1;					//!< Right (d-pad)
-		int down:1;						//!< Down (d-pad)
-		int left:1;						//!< Left (d-pad)
-		int L:1;						//!< L (shoulder)
-		int R:1;						//!< R (shoulder)
-		int reserved2:2;				//!< For padding, do not use
-		int triangle:1;					//!< Triangle
-		int circle:1;					//!< Circle
-		int cross:1;					//!< Cross
-		int square:1;					//!< Square
-		int home:1;						//!< Home (seems not to work)
-		int hold:1;						//!< Hold (power switch in the opposite direction)
-		int reserved3:5;				//!< For padding, do not use
-		int note:1;						//!< Note (seems not to work)
-	};
-	unsigned int value;					//!< 32-bit value containing all keys
+/** 
+ * @union OSL_KEYLIST
+ * @brief List of keys.
+ *
+ * This union represents the state of the buttons on a controller.
+ */
+typedef union {
+    struct {
+        int select:1;           //!< Select button.
+        int reserved1:2;        //!< Reserved for padding, do not use.
+        int start:1;            //!< Start button.
+        int up:1;               //!< Up on the D-pad.
+        int right:1;            //!< Right on the D-pad.
+        int down:1;             //!< Down on the D-pad.
+        int left:1;             //!< Left on the D-pad.
+        int L:1;                //!< L shoulder button.
+        int R:1;                //!< R shoulder button.
+        int reserved2:2;        //!< Reserved for padding, do not use.
+        int triangle:1;         //!< Triangle button.
+        int circle:1;           //!< Circle button.
+        int cross:1;            //!< Cross button.
+        int square:1;           //!< Square button.
+        int home:1;             //!< Home button (may not work).
+        int hold:1;             //!< Hold button (power switch in the opposite direction).
+        int reserved3:5;        //!< Reserved for padding, do not use.
+        int note:1;             //!< Note button (may not work).
+    };
+    unsigned int value;         //!< 32-bit value containing all keys.
 } OSL_KEYLIST;
 
+/**
+ * @struct OSL_CONTROLLER
+ * @brief Controller type.
+ *
+ * This structure represents the state of the controller, including held, pressed, and released keys.
+ */
+typedef struct {
+    OSL_KEYLIST held;                           //!< Keys currently held down.
+    OSL_KEYLIST pressed;                        //!< Keys pressed (reported once when the user presses it).
+    OSL_KEYLIST released;                       //!< Keys released (reported once when the user releases it).
+    OSL_KEYLIST lastHeld;                       //!< Last held state, for handling auto-repeat without interference.
 
+    short autoRepeatInit;                       //!< Time for the initialization of the auto-repeat feature.
+    short autoRepeatInterval;                   //!< Interval before the auto-repeat feature activates.
+    int autoRepeatMask;                         //!< Keys affected by the auto-repeat feature.
+    short autoRepeatCounter;                    //!< Internal counter for auto-repeat.
 
+    signed char analogToDPadSensivity;          //!< Minimum sensitivity for analog to D-pad conversion. 0 disables this feature, 127 is maximum sensitivity.
 
-/** Controller type. */
-typedef struct		{
-	OSL_KEYLIST held;						//!< Keys currently down (held)
-	OSL_KEYLIST pressed;					//!< Keys pressed (only reported once when the user pressed it)
-	OSL_KEYLIST released;					//!< Keys released (only reported once when the user releases it)
-	OSL_KEYLIST lastHeld;					//!< Allows you to trick with the held member without messing up the auto-repeat feature
+    signed char analogX;                        //!< Horizontal position of the analog stick (-128: left, +127: right).
+    signed char analogY;                        //!< Vertical position of the analog stick (-128: top, +127: bottom).
 
-	short autoRepeatInit;					//!< Time for the initialization of the autorepeat feature
-	short autoRepeatInterval;				//!< Interval before the autorepeat feature is switched on (the time the user must let the key down)
-	int autoRepeatMask;						//!< Keys affected by the autorepeat feature
-	short autoRepeatCounter;				//!< Counter (internal)
-
-	signed char analogToDPadSensivity;		//!< Minimum sensivity for the analog to d-pad function in each direct, 0 means disable analog to d-pad. 127 is the maximum: the stick has to be completely pressed to be detected. A typical value is 80.
-
-	signed char analogX;					//!< Horizontal position of the analog stick (-128: left, +127: right)
-	signed char analogY;					//!< Vertical position of the analog stick (-128: top, +127: bottom)
-
-    int holdAffectsAnalog;
+    int holdAffectsAnalog;                      //!< Determines if HOLD affects the analog stick.
 } OSL_CONTROLLER;
 
-
-/** Bit number for each key in the 'value' field. One of these values is returned by oslKbhit or oslWaitKey.
-
-\code
-keyPressed = oslWaitKey();
-if (keyPressed == OSL_KEY_START)
-	...
-\endcode */
-enum OSL_KEY_BITS		{
-	OSL_KEY_SELECT=1,						//!< Select key
-	OSL_KEY_START=4,						//!< Start key
-	OSL_KEY_UP=5,							//!< Up d-pad key
-	OSL_KEY_RIGHT=6,						//!< Right d-pad key
-	OSL_KEY_DOWN=7,							//!< Down d-pad key
-	OSL_KEY_LEFT=8,							//!< Left d-pad key
-	OSL_KEY_L=9,							//!< L (shoulder) key
-	OSL_KEY_R=10,							//!< R (shoulder) key
-	OSL_KEY_TRIANGLE=13,					//!< Triangle key
-	OSL_KEY_CIRCLE=14,						//!< Circle key
-	OSL_KEY_CROSS=15,						//!< Cross key
-	OSL_KEY_SQUARE=16,						//!< Square key
-	OSL_KEY_HOME=17,						//!< Home key (does not work in normal (user) operation)
-	OSL_KEY_HOLD=18,						//!< Hold (power switch in the opposite direction) key
-	OSL_KEY_NOTE=24							//!< Note key (same remark as Home)
+/**
+ * @enum OSL_KEY_BITS
+ * @brief Bit number for each key in the 'value' field.
+ *
+ * This enumeration defines the bit positions for each key in the `value` field of `OSL_KEYLIST`.
+ */
+enum OSL_KEY_BITS {
+    OSL_KEY_SELECT = 1,            //!< Select key.
+    OSL_KEY_START = 4,             //!< Start key.
+    OSL_KEY_UP = 5,                //!< Up D-pad key.
+    OSL_KEY_RIGHT = 6,             //!< Right D-pad key.
+    OSL_KEY_DOWN = 7,              //!< Down D-pad key.
+    OSL_KEY_LEFT = 8,              //!< Left D-pad key.
+    OSL_KEY_L = 9,                 //!< L shoulder key.
+    OSL_KEY_R = 10,                //!< R shoulder key.
+    OSL_KEY_TRIANGLE = 13,         //!< Triangle key.
+    OSL_KEY_CIRCLE = 14,           //!< Circle key.
+    OSL_KEY_CROSS = 15,            //!< Cross key.
+    OSL_KEY_SQUARE = 16,           //!< Square key.
+    OSL_KEY_HOME = 17,             //!< Home key (may not work in normal operation).
+    OSL_KEY_HOLD = 18,             //!< Hold key (power switch in the opposite direction).
+    OSL_KEY_NOTE = 24              //!< Note key (may not work).
 };
-
-/** Mask for each key in the 'value' field. To extract for example the select key, you can do the following:
-\code
-oslReadKeys();
-if (osl_pad.held.value & OSL_KEYMASK_SELECT)	...
-//This is equivalent to:
-if (osl_pad.held.select)	...
-\endcode
-
-The keymasks description is exactly the same as keybits, they are just named OSL_KEYMASK_xxx instead of OSL_KEY_xxx. */
-enum OSL_KEY_MASKS			{
-	OSL_KEYMASK_SELECT=0x1,
-	OSL_KEYMASK_START=0x8,
-	OSL_KEYMASK_UP=0x10,
-	OSL_KEYMASK_RIGHT=0x20,
-	OSL_KEYMASK_DOWN=0x40,
-	OSL_KEYMASK_LEFT=0x80,
-	OSL_KEYMASK_L=0x100,
-	OSL_KEYMASK_R=0x200,
-	OSL_KEYMASK_TRIANGLE=0x1000,
-	OSL_KEYMASK_CIRCLE=0x2000,
-	OSL_KEYMASK_CROSS=0x4000,
-	OSL_KEYMASK_SQUARE=0x8000,
-	OSL_KEYMASK_HOME=0x10000,
-	OSL_KEYMASK_HOLD=0x20000,
-	OSL_KEYMASK_NOTE=0x800000
-};
-
-
-/** Sets the auto-repeat parameters (all at once).
-	\param keys
-		Sets the keys affected by the autorepeat feature. If these keys are held for long enough, they will be reported more times in the pressed member in the osl_pad structure. It's the ideal thing to
-		handle a menu, just check for the 'pressed' member and move the cursor when it's set. The auto-repeat feature will automatically work. Typical keys the user would expect to be auto-repeated are:
-		OSL_KEYMASK_UP|OSL_KEYMASK_RIGHT|OSL_KEYMASK_DOWN|OSL_KEYMASK_LEFT|OSL_KEYMASK_R|OSL_KEYMASK_L. As you see, just OR the masks of the keys you want to be auto-repeated.
-	\param init
-		Time (in number of calls, so at 60 fps, 60 = 1 second) before the auto-repeat feature turns on. Usually you must wait a while (1/2 second or more) before the auto-repeat is turned on, but once
-		it's on, the key will be repeated more than each 1/2 second. A typical value here is 40 (2/3 second).
-	\param interval
-		Time interval between each key repeat when the auto-repeat has been turned on. A typical value is 10 (1/6 of a second); with the example above, you would press the key, then 2/3 second later it
-		begins to auto-repeat the key each 1/6 second.
-*/
-#define oslSetKeyAutorepeat(keys,init,interval)		( osl_keys->autoRepeatMask = keys, osl_keys->autoRepeatInit = init, osl_keys->autoRepeatInterval = interval )
-/** Separate routine setting the key auto-repeat mask. */
-#define oslSetKeyAutorepeatMask(mask)		(osl_keys->autoRepeatMask=mask)
-/** Separate routine setting the key auto-repeat initialization value. */
-#define oslSetKeyAutorepeatInit(value)		(osl_keys->autoRepeatInit=value)
-/** Separate routine setting the key auto-repeat interval value. */
-#define oslSetKeyAutorepeatInterval(value)	(osl_keys->autoRepeatInterval=value)
-
-/** Enables or disable automatic redirection from the analog stick to D-Pad buttons (down, left, etc.).
-	\param sensivity
-		Sensivity for the analog press. Analog values go from -128 to 127, so the maximum sensivity value you can set is 127,
-		meaning the stick needs to be at least at -127 or +127 in each direction to be treated as a directional key.
-
-		A typical value is 80, this leaves a sufficient space to avoid unintentioned diagonals, but is also small enough to be sensitive and
-		comfortable.
-
-\b Note: Diagonal keys are supported as well with the stick, and this is really a good idea to at least enable this if you don't want to threat
-the stick separately. Some people (including me) have a weak D-Pad and it's extremely hard to play any game or app that needs the up/down
-keys, or even worse: diagonals.
-
-\code
-//Enable default analog handler
-oslSetKeyAnalogToDPad(80);
-//Read keys
-oslReadKeys();
-//The stick is upwards OR the D-pad's up direction is held
-if (osl_pad.held.up)
-	{}
-
-//If you want to differenciate stick and D-pad, you can also do something like this:
-
-//Make sure default analog handler is disabled!
-oslSetKeyAnalogToDPad(0);
-oslReadKeys();
-//D-Pad
-if (osl_pad.held.up)
-	{}
-//Stick
-if (osl_pad.analogY < -80)
-	{}
-\endcode */
-#define oslSetKeyAnalogToDPad(sensivity)	(osl_keys->analogToDPadSensivity = sensivity)
-
-/** Current keys. Only here for compatibility, use osl_pad now. */
-extern OSL_CONTROLLER *osl_keys;
-/** Current keys. In this structure you will find three members: pressed, released and held.
-- pressed: keys that were just pressed, reported once when the user pressed it but not after.
-- held: always reported while the user holds the key.
-- released: reported when the user just releases a pressed key.
-
-Each of these members is an union, containing a structure of type OSL_KEYLIST (contains a member for each key):
-\code
-oslReadKeys();
-if (osl_pad.pressed.start)
-	oslDebug("A pause should be thrown!");
-if (osl_pad.held.up)
-	oslDebug("Moving the main character upwards!");
-
-\endcode
-
-Look at OSL_CONTROLLER for more information. */
-extern OSL_CONTROLLER osl_pad;
-
-
-/** Reads the current controller state and stores the result in the osl_pad structure. Returns a pointer to the actual key structure. It may seem cleaner to store this pointer and access data from it,
-but you can do however you want. */
-extern OSL_CONTROLLER *oslReadKeys();
-
-/** Sets an external function to read keys.
-You can pass to it a function from a kernel prx, so you'll be able to read all buttons (VOLUME_UP, VOLUME_DOWN, NOTE...)
-*/
-extern int oslSetReadKeysFunction(int (*sceCtrlReadBufferPositive)(SceCtrlData *pad_data, int count));
-
-/** Unsets the function set with oslSetReadKeysFunction
-*/
-extern int oslUnsetReadKeysFunction();
-
-/** Decide if HOLD will affect also the analog (default=NO).
-*/
-extern int oslSetHoldForAnalog(int holdForAnalog);
-
-/** Waits for a key and returns its code. Compare the code against one of the OSL_KEYBITS values. */
-extern int oslWaitKey();
-/** Determines whether a key is currently buffered and returns its code, or 0 else. Compare the code against one of the OSL_KEYBITS values. */
-extern int oslKbhit();
-/** Flushes the key buffer, removing the pending key (retrievable with oslKbhit). */
-extern void oslFlushKey();
-
-
-
-
-
-//Remote functions:
-/** List of remote keys. */
-typedef union		{
-	struct		{
-		int rmplaypause:1;				//!< Play/Pause
-		int reserved1:1;				//!< For padding, do not use
-		int rmforward:1;				//!< Formward
-		int rmback:1;					//!< Back
-		int rmvolup:1;					//!< Volume Up
-		int rmvoldown:1;				//!< Volume Down
-		int rmhold:1;					//!< Hold
-		int reserved2:1;				//!< For padding, do not use
-	};
-	u32 value;							//!< 32-bit value containing all keys
-} OSL_REMOTEKEYLIST;
-
-
-/** Remote Controller type. */
-typedef struct		{
-	OSL_REMOTEKEYLIST held;						//!< Keys currently down (held)
-	OSL_REMOTEKEYLIST pressed;					//!< Keys pressed (only reported once when the user pressed it)
-	OSL_REMOTEKEYLIST released;					//!< Keys released (only reported once when the user releases it)
-	OSL_REMOTEKEYLIST lastHeld;					//!< Allows you to trick with the held member without messing up the auto-repeat feature
-
-	short autoRepeatInit;					//!< Time for the initialization of the autorepeat feature
-	short autoRepeatInterval;				//!< Interval before the autorepeat feature is switched on (the time the user must let the key down)
-	int autoRepeatMask;						//!< Keys affected by the autorepeat feature
-	short autoRepeatCounter;				//!< Counter (internal)
-} OSL_REMOTECONTROLLER;
-
-extern OSL_REMOTECONTROLLER *osl_remotekeys;
-
-/** Current remote keys. In this structure you will find three members: pressed, released and held.
-- pressed: keys that were just pressed, reported once when the user pressed it but not after.
-- held: always reported while the user holds the key.
-- released: reported when the user just releases a pressed key.
-
-Each of these members is an union, containing a structure of type OSL_REMOTEKEYLIST (contains a member for each key):
-\code
-oslReadRemoteKeys();
-if (osl_remote.pressed.rmplaypause)
-	oslDebug("A pause should be thrown!");
-if (osl_remote.held.rmforward)
-	oslDebug("Do something!");
-
-\endcode
-
-Look at OSL_REMOTECONTROLLER for more information. */
-extern OSL_REMOTECONTROLLER osl_remote;
-
- /** Reads the current remote controller state and stores the result in the osl_remote structure. Returns a pointer to the actual key structure. It may seem cleaner to store this pointer and access data from it,
-but you can do however you want. */
-extern OSL_REMOTECONTROLLER *oslReadRemoteKeys();
-
-/** Flushes the remote key buffer, removing the pending key. */
-extern void oslFlushRemoteKey();
-
-/** Sets the auto-repeat parameters (all at once).
-	\param keys
-		Sets the keys affected by the autorepeat feature. If these keys are held for long enough, they will be reported more times in the pressed member in the osl_pad structure. It's the ideal thing to
-		handle a menu, just check for the 'pressed' member and move the cursor when it's set. The auto-repeat feature will automatically work. Typical keys the user would expect to be auto-repeated are:
-		OSL_KEYMASK_UP|OSL_KEYMASK_RIGHT|OSL_KEYMASK_DOWN|OSL_KEYMASK_LEFT|OSL_KEYMASK_R|OSL_KEYMASK_L. As you see, just OR the masks of the keys you want to be auto-repeated.
-	\param init
-		Time (in number of calls, so at 60 fps, 60 = 1 second) before the auto-repeat feature turns on. Usually you must wait a while (1/2 second or more) before the auto-repeat is turned on, but once
-		it's on, the key will be repeated more than each 1/2 second. A typical value here is 40 (2/3 second).
-	\param interval
-		Time interval between each key repeat when the auto-repeat has been turned on. A typical value is 10 (1/6 of a second); with the example above, you would press the key, then 2/3 second later it
-		begins to auto-repeat the key each 1/6 second.
-*/
-#define oslSetRemoteKeyAutorepeat(keys,init,interval)		( osl_remotekeys->autoRepeatMask = keys, osl_remotekeys->autoRepeatInit = init, osl_remotekeys->autoRepeatInterval = interval )
-/** Separate routine setting the key auto-repeat mask. */
-#define oslSetRemoteKeyAutorepeatMask(mask)		(osl_remotekeys->autoRepeatMask=mask)
-/** Separate routine setting the key auto-repeat initialization value. */
-#define oslSetRemoteKeyAutorepeatInit(value)		(osl_remotekeys->autoRepeatInit=value)
-/** Separate routine setting the key auto-repeat interval value. */
-#define oslSetRemoteKeyAutorepeatInterval(value)	(osl_remotekeys->autoRepeatInterval=value)
 
 /**
-Determines whether the remote is plugged in.
-@return 1 if the remote is plugged in, else 0.
-*/
+ * @enum OSL_KEY_MASKS
+ * @brief Mask for each key in the 'value' field.
+ *
+ * This enumeration defines the bitmasks for each key in the `value` field of `OSL_KEYLIST`.
+ */
+enum OSL_KEY_MASKS {
+    OSL_KEYMASK_SELECT = 0x1,
+    OSL_KEYMASK_START = 0x8,
+    OSL_KEYMASK_UP = 0x10,
+    OSL_KEYMASK_RIGHT = 0x20,
+    OSL_KEYMASK_DOWN = 0x40,
+    OSL_KEYMASK_LEFT = 0x80,
+    OSL_KEYMASK_L = 0x100,
+    OSL_KEYMASK_R = 0x200,
+    OSL_KEYMASK_TRIANGLE = 0x1000,
+    OSL_KEYMASK_CIRCLE = 0x2000,
+    OSL_KEYMASK_CROSS = 0x4000,
+    OSL_KEYMASK_SQUARE = 0x8000,
+    OSL_KEYMASK_HOME = 0x10000,
+    OSL_KEYMASK_HOLD = 0x20000,
+    OSL_KEYMASK_NOTE = 0x800000
+};
+
+/**
+ * @brief Sets the auto-repeat parameters for keys.
+ * @param keys The keys affected by the auto-repeat feature.
+ * @param init Time (in number of calls) before the auto-repeat feature turns on.
+ * @param interval Time interval between each key repeat when the auto-repeat has been turned on.
+ */
+#define oslSetKeyAutorepeat(keys, init, interval) \
+    (osl_keys->autoRepeatMask = keys, osl_keys->autoRepeatInit = init, osl_keys->autoRepeatInterval = interval)
+
+/**
+ * @brief Sets the key auto-repeat mask.
+ * @param mask The key auto-repeat mask.
+ */
+#define oslSetKeyAutorepeatMask(mask) \
+    (osl_keys->autoRepeatMask = mask)
+
+/**
+ * @brief Sets the key auto-repeat initialization value.
+ * @param value The initialization value for auto-repeat.
+ */
+#define oslSetKeyAutorepeatInit(value) \
+    (osl_keys->autoRepeatInit = value)
+
+/**
+ * @brief Sets the key auto-repeat interval value.
+ * @param value The interval value for auto-repeat.
+ */
+#define oslSetKeyAutorepeatInterval(value) \
+    (osl_keys->autoRepeatInterval = value)
+
+/**
+ * @brief Enables or disables automatic redirection from the analog stick to D-pad buttons.
+ * @param sensivity Sensitivity for the analog press. A typical value is 80.
+ */
+#define oslSetKeyAnalogToDPad(sensivity) \
+    (osl_keys->analogToDPadSensivity = sensivity)
+
+/** 
+ * @var osl_keys
+ * @brief Current keys. Only here for compatibility, use osl_pad now.
+ */
+extern OSL_CONTROLLER *osl_keys;
+
+/** 
+ * @var osl_pad
+ * @brief Current keys.
+ *
+ * This structure holds the current state of the controller.
+ */
+extern OSL_CONTROLLER osl_pad;
+
+/**
+ * @brief Reads the current controller state and stores the result in the osl_pad structure.
+ * @return A pointer to the actual key structure.
+ */
+extern OSL_CONTROLLER *oslReadKeys();
+
+/**
+ * @brief Sets an external function to read keys.
+ * @param sceCtrlReadBufferPositive The external function to read keys.
+ * @return 0 on success, non-zero on failure.
+ */
+extern int oslSetReadKeysFunction(int (*sceCtrlReadBufferPositive)(SceCtrlData *pad_data, int count));
+
+/**
+ * @brief Unsets the function set with oslSetReadKeysFunction.
+ * @return 0 on success, non-zero on failure.
+ */
+extern int oslUnsetReadKeysFunction();
+
+/**
+ * @brief Decides if HOLD will affect the analog stick.
+ * @param holdForAnalog 1 to enable, 0 to disable.
+ * @return 0 on success, non-zero on failure.
+ */
+extern int oslSetHoldForAnalog(int holdForAnalog);
+
+/**
+ * @brief Waits for a key and returns its code.
+ * @return The key code.
+ */
+extern int oslWaitKey();
+
+/**
+ * @brief Determines whether a key is currently buffered and returns its code.
+ * @return The key code if a key is buffered, 0 otherwise.
+ */
+extern int oslKbhit();
+
+/**
+ * @brief Flushes the key buffer, removing the pending key.
+ */
+extern void oslFlushKey();
+
+/**
+ * @union OSL_REMOTEKEYLIST
+ * @brief List of remote keys.
+ *
+ * This union represents the state of the buttons on a remote controller.
+ */
+typedef union {
+    struct {
+        int rmplaypause:1;       //!< Play/Pause button.
+        int reserved1:1;         //!< Reserved for padding, do not use.
+        int rmforward:1;         //!< Forward button.
+        int rmback:1;            //!< Back button.
+        int rmvolup:1;           //!< Volume Up button.
+        int rmvoldown:1;         //!< Volume Down button.
+        int rmhold:1;            //!< Hold button.
+        int reserved2:1;         //!< Reserved for padding, do not use.
+    };
+    u32 value;                    //!< 32-bit value containing all keys.
+} OSL_REMOTEKEYLIST;
+
+/**
+ * @struct OSL_REMOTECONTROLLER
+ * @brief Remote Controller type.
+ *
+ * This structure represents the state of the remote controller, including held, pressed, and released keys.
+ */
+typedef struct {
+    OSL_REMOTEKEYLIST held;                           //!< Keys currently held down.
+    OSL_REMOTEKEYLIST pressed;                        //!< Keys pressed (reported once when the user presses it).
+    OSL_REMOTEKEYLIST released;                       //!< Keys released (reported once when the user releases it).
+    OSL_REMOTEKEYLIST lastHeld;                       //!< Last held state, for handling auto-repeat without interference.
+
+    short autoRepeatInit;                             //!< Time for the initialization of the auto-repeat feature.
+    short autoRepeatInterval;                         //!< Interval before the auto-repeat feature activates.
+    int autoRepeatMask;                               //!< Keys affected by the auto-repeat feature.
+    short autoRepeatCounter;                          //!< Internal counter for auto-repeat.
+} OSL_REMOTECONTROLLER;
+
+/** 
+ * @var osl_remotekeys
+ * @brief Current remote keys. 
+ *
+ * This structure holds the current state of the remote controller.
+ */
+extern OSL_REMOTECONTROLLER *osl_remotekeys;
+
+/**
+ * @var osl_remote
+ * @brief Current remote keys.
+ *
+ * This structure holds the current state of the remote controller.
+ */
+extern OSL_REMOTECONTROLLER osl_remote;
+
+/**
+ * @brief Reads the current remote controller state and stores the result in the osl_remote structure.
+ * @return A pointer to the actual key structure.
+ */
+extern OSL_REMOTECONTROLLER *oslReadRemoteKeys();
+
+/**
+ * @brief Flushes the remote key buffer, removing the pending key.
+ */
+extern void oslFlushRemoteKey();
+
+/**
+ * @brief Sets the auto-repeat parameters for remote keys.
+ * @param keys The keys affected by the auto-repeat feature.
+ * @param init Time (in number of calls) before the auto-repeat feature turns on.
+ * @param interval Time interval between each key repeat when the auto-repeat has been turned on.
+ */
+#define oslSetRemoteKeyAutorepeat(keys, init, interval) \
+    (osl_remotekeys->autoRepeatMask = keys, osl_remotekeys->autoRepeatInit = init, osl_remotekeys->autoRepeatInterval = interval)
+
+/**
+ * @brief Sets the remote key auto-repeat mask.
+ * @param mask The key auto-repeat mask.
+ */
+#define oslSetRemoteKeyAutorepeatMask(mask) \
+    (osl_remotekeys->autoRepeatMask = mask)
+
+/**
+ * @brief Sets the remote key auto-repeat initialization value.
+ * @param value The initialization value for auto-repeat.
+ */
+#define oslSetRemoteKeyAutorepeatInit(value) \
+    (osl_remotekeys->autoRepeatInit = value)
+
+/**
+ * @brief Sets the remote key auto-repeat interval value.
+ * @param value The interval value for auto-repeat.
+ */
+#define oslSetRemoteKeyAutorepeatInterval(value) \
+    (osl_remotekeys->autoRepeatInterval = value)
+
+/**
+ * @brief Determines whether the remote is plugged in.
+ * @return 1 if the remote is plugged in, 0 otherwise.
+ */
 int oslIsRemoteExist();
 
 /** @} */ // end of keys
-
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### OSL Keys Module Documentation

The `OSL Keys` module in OSLib handles controller and remote inputs, offering key state management, auto-repeat functionality, and analog stick handling.

#### Key Components

- **OSL_KEYLIST / OSL_CONTROLLER**: Structures for tracking controller button states (held, pressed, released) and analog stick positions.
- **OSL_REMOTEKEYLIST / OSL_REMOTECONTROLLER**: Similar structures for remote controllers.

#### Macros

- **oslSetKeyAutorepeat**: Configures auto-repeat for keys.
- **oslSetKeyAnalogToDPad**: Maps analog stick movements to D-pad inputs.

#### Functions

- **oslReadKeys**: Updates the `osl_pad` structure with the current controller state.
- **oslWaitKey / oslKbhit**: Waits for or checks if a key is pressed.
- **oslFlushKey**: Clears the key buffer.
- **oslReadRemoteKeys**: Updates the remote controller state.

#### Notes

- Supports auto-repeat for long key presses and analog-to-D-pad mapping for better input handling.