### PR TITLE
Optimized oslGetImagePixel function for better readability and performance

### DIFF
--- a/src/image/oslGetImagePixel.c
+++ b/src/image/oslGetImagePixel.c
@@ -1,26 +1,29 @@
 #include "oslib.h"
 
-//Retourne la valeur d'un pixel sur une image - lent
-int oslGetImagePixel(OSL_IMAGE *img, unsigned int x, unsigned int y)			{
-	void *pPixel = oslGetUncachedPtr(oslGetSwizzledPixelAddr(img, x, y));
+// Retrieves the value of a pixel on an image - optimized
+int oslGetImagePixel(OSL_IMAGE *img, unsigned int x, unsigned int y) {
+    if (x >= img->sizeX || y >= img->sizeY) {
+        return -1; // Return error for out-of-bounds coordinates
+    }
 
-	//Because of unsigned, we don't have to check if they're greater than 0!
-	if (/*x >= 0 &&*/ x < img->sizeX /*&& y >= 0*/ && y < img->sizeY)			{
-	   switch (img->pixelFormat)			{
-			case OSL_PF_8888:
-				return *(u32*)pPixel;
+    void *pPixel = oslGetUncachedPtr(oslGetSwizzledPixelAddr(img, x, y));
 
-			case OSL_PF_5650:
-			case OSL_PF_5551:
-			case OSL_PF_4444:
-				return *(u16*)pPixel;
+    switch (img->pixelFormat) {
+        case OSL_PF_8888:
+            return *(u32*)pPixel;
 
-			case OSL_PF_8BIT:
-				return *(u8*)pPixel;
+        case OSL_PF_5650:
+        case OSL_PF_5551:
+        case OSL_PF_4444:
+            return *(u16*)pPixel;
 
-			case OSL_PF_4BIT:
-				return *(u8*)pPixel & (15 << ((x & 1) << 2));
-		}
-	}
-	return -1;
+        case OSL_PF_8BIT:
+            return *(u8*)pPixel;
+
+        case OSL_PF_4BIT:
+            return (*(u8*)pPixel >> ((x & 1) * 4)) & 0xF; // Extract the correct 4-bit value
+
+        default:
+            return -1; // Return error for unsupported formats
+    }
 }


### PR DESCRIPTION
- Added early boundary checks for x and y coordinates to prevent unnecessary processing.
- Simplified switch-case structure and improved 4-bit pixel format handling.
- Enhanced error handling for unsupported pixel formats.
- Ensured the function returns -1 for out-of-bounds or unsupported cases.