### PR TITLE
Improve oslLockImage and oslUnlockImage functions for clarity and readability

### DIFF
--- a/src/image/oslLockImage.c
+++ b/src/image/oslLockImage.c
@@ -1,56 +1,86 @@
 #include "oslib.h"
 
 /*
-	Fonctions spéciales PC
-	Permet d'accéder en soft à une image sélectionnée comme drawbuffer ou texture
+    Special PC Functions
+    Allows access to an image selected as a draw buffer or texture
 */
 void oslLockImage(OSL_IMAGE *img)
 {
-	//Drawbuffer courant?
-	if (img == osl_curBuf)			{
-		oslSyncDrawing();
-		//Avec OpenGL, il faut copier le contenu du drawbuffer sur l'image (vu qu'on va l'utiliser)
-		#ifndef PSP
-			//On doit désactiver (temporairement) le texturage 2D
-			int bTextureEnabled = glIsEnabled(GL_TEXTURE_2D), bBlendingEnabled = glIsEnabled(GL_BLEND);
-			glDisable(GL_TEXTURE_2D);
-			glDisable(GL_BLEND);
-			//Lit les données du backbuffer dans l'image utilisée jusque là comme drawbuffer
-			emuGlReadPixels(0, 272-osl_curBuf->sizeY, osl_curBuf->sysSizeX, osl_curBuf->sizeY, GL_RGBA, osl_curBuf->pixelFormat, osl_curBuf->data);
-			//Réactive si jamais
-			if (bTextureEnabled)
-				glEnable(GL_TEXTURE_2D);
-			if (bBlendingEnabled)
-				glEnable(GL_BLEND);
-		#endif
-	}
+    // Check if the image is the current draw buffer
+    if (img == osl_curBuf) {
+        // Synchronize drawing before accessing the draw buffer
+        oslSyncDrawing();
+        
+        #ifndef PSP
+            // On non-PSP platforms, copy the contents of the draw buffer to the image
+            int textureEnabled = glIsEnabled(GL_TEXTURE_2D);
+            int blendingEnabled = glIsEnabled(GL_BLEND);
+
+            // Temporarily disable 2D texturing and blending
+            glDisable(GL_TEXTURE_2D);
+            glDisable(GL_BLEND);
+
+            // Read the pixels from the back buffer into the image data
+            emuGlReadPixels(
+                0, 
+                272 - osl_curBuf->sizeY, 
+                osl_curBuf->sysSizeX, 
+                osl_curBuf->sizeY, 
+                GL_RGBA, 
+                osl_curBuf->pixelFormat, 
+                osl_curBuf->data
+            );
+
+            // Re-enable texturing and blending if they were previously enabled
+            if (textureEnabled) {
+                glEnable(GL_TEXTURE_2D);
+            }
+            if (blendingEnabled) {
+                glEnable(GL_BLEND);
+            }
+        #endif
+    }
 }
 
-//A appeler une fois terminé
+// Call this function once the image operations are complete
 void oslUnlockImage(OSL_IMAGE *img)
 {
-//	if (img->location == OSL_IN_RAM)
-		oslUncacheImage(img);
-	//Texture courante?
-	if (img->data == osl_curTexture)
-		osl_curTexture = NULL;
-	//Avec OpenGL, on recopie le contenu de l'image (modifiée) vers le framebuffer
-	#ifndef PSP
-		if (img == osl_curBuf)			{
-			//On doit désactiver (temporairement) le texturage 2D
-			int bTextureEnabled = glIsEnabled(GL_TEXTURE_2D), bBlendingEnabled = glIsEnabled(GL_BLEND);
-			glDisable(GL_TEXTURE_2D);
-			glDisable(GL_BLEND);
-			//Lit les données du backbuffer dans l'image utilisée jusque là comme drawbuffer
-			glRasterPos2i(0, 0);
-			glPixelZoom(1, -1);
-			glDrawPixels(img->sysSizeX, img->sizeY, GL_RGBA, emu_pixelPhysFormats[img->pixelFormat], img->data);
-			//Réactive si jamais
-			if (bTextureEnabled)
-				glEnable(GL_TEXTURE_2D);
-			if (bBlendingEnabled)
-				glEnable(GL_BLEND);
-		}
-	#endif
-}
+    // Uncache the image if it is stored in RAM
+    oslUncacheImage(img);
 
+    // Check if the image is the current texture
+    if (img->data == osl_curTexture) {
+        osl_curTexture = NULL;
+    }
+
+    #ifndef PSP
+        // On non-PSP platforms, copy the modified image data back to the framebuffer
+        if (img == osl_curBuf) {
+            int textureEnabled = glIsEnabled(GL_TEXTURE_2D);
+            int blendingEnabled = glIsEnabled(GL_BLEND);
+
+            // Temporarily disable 2D texturing and blending
+            glDisable(GL_TEXTURE_2D);
+            glDisable(GL_BLEND);
+
+            // Write the image data back to the framebuffer
+            glRasterPos2i(0, 0);
+            glPixelZoom(1, -1);
+            glDrawPixels(
+                img->sysSizeX, 
+                img->sizeY, 
+                GL_RGBA, 
+                emu_pixelPhysFormats[img->pixelFormat], 
+                img->data
+            );
+
+            // Re-enable texturing and blending if they were previously enabled
+            if (textureEnabled) {
+                glEnable(GL_TEXTURE_2D);
+            }
+            if (blendingEnabled) {
+                glEnable(GL_BLEND);
+            }
+        }
+    #endif
+}


### PR DESCRIPTION
- Enhanced comments to better describe the purpose and behavior of the functions.
- Reformatted code for consistent alignment and readability.
- Renamed variables to follow a more consistent naming convention (`bTextureEnabled` to `textureEnabled`, `bBlendingEnabled` to `blendingEnabled`).
- Clarified platform-specific operations with proper separation between PSP and non-PSP code.