### PR TITLE
Refactor oslSetImagePixel function for clarity and robustness

### DIFF
--- a/src/image/oslSetImagePixel.c
+++ b/src/image/oslSetImagePixel.c
@@ -1,30 +1,35 @@
 #include "oslib.h"
 
-//Dessine un pixel sur une image - lent
-void oslSetImagePixel(OSL_IMAGE *img, unsigned int x, unsigned int y, int pixelValue)			{
-	void *pPixel = oslGetUncachedPtr(oslGetSwizzledPixelAddr(img, x, y));
+// Draws a pixel on an image - slow
+void oslSetImagePixel(OSL_IMAGE *img, unsigned int x, unsigned int y, int pixelValue) {
+    // Early exit if the pixel is out of bounds (unsigned check covers non-negative range)
+    if (x >= img->sizeX || y >= img->sizeY) {
+        return;
+    }
 
-	//Clipping - use of unsigned avoids checking if it's greater than 0.
-	if (/*x >= 0 &&*/ x < img->sizeX && /*y >= 0 &&*/ y < img->sizeY)			{
-		switch (img->pixelFormat)			{
-			case OSL_PF_8888:
-				*(u32*)pPixel = pixelValue;
-				break;
+    // Get the pointer to the pixel's address in the image, avoiding cache issues
+    void *pPixel = oslGetUncachedPtr(oslGetSwizzledPixelAddr(img, x, y));
 
-			case OSL_PF_5650:
-			case OSL_PF_5551:
-			case OSL_PF_4444:
-				*(u16*)pPixel = pixelValue;
-				break;
+    // Set the pixel value based on the image's pixel format
+    switch (img->pixelFormat) {
+        case OSL_PF_8888:
+            *(u32*)pPixel = (u32)pixelValue;
+            break;
 
-			case OSL_PF_8BIT:
-				*(u8*)pPixel = pixelValue;
-				break;
+        case OSL_PF_5650:
+        case OSL_PF_5551:
+        case OSL_PF_4444:
+            *(u16*)pPixel = (u16)pixelValue;
+            break;
 
-			case OSL_PF_4BIT:
-				*(u8*)pPixel &= ~(15 << ((x & 1) << 2));
-				*(u8*)pPixel |= (pixelValue & 15) << ((x & 1) << 2);
-				break;
-		}
-	}
+        case OSL_PF_8BIT:
+            *(u8*)pPixel = (u8)pixelValue;
+            break;
+
+        case OSL_PF_4BIT: {
+			*(u8*)pPixel &= ~(15 << ((x & 1) << 2));
+			*(u8*)pPixel |= (pixelValue & 15) << ((x & 1) << 2);
+            break;
+        }
+    }
 }


### PR DESCRIPTION
### Summary

Refactored the `oslSetImagePixel` function to improve clarity and robustness.

### Key Changes

- Simplified bounds checking with an early return for out-of-bounds pixels.
- Ensured type safety with explicit casts for pixel value assignments.

### Impact

These changes enhance maintainability and readability without altering the function's behavior.