### PR TITLE
Finalize CMake setup for OSLib project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Ignore compiled object files
 *.o
 
+# Ignore build directory
+build
+
 # Ignore macOS system file
 .DS_Store
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,171 @@
+cmake_minimum_required(VERSION 3.10)
+project(OSLib C CXX ASM)
+
+# Load the PSP platform configuration
+set(CMAKE_SYSTEM_NAME PSP)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR mips)
+set(CMAKE_SYSTEM_CMAKE_PLATFORM_PATH "${CMAKE_SOURCE_DIR}/Platform")
+
+include("${CMAKE_SYSTEM_CMAKE_PLATFORM_PATH}/PSP.cmake")
+
+# PSP Firmware version
+add_definitions(-DPSP_FW_VERSION=371)
+
+# Set the output library
+set(TARGET_LIB osl)
+add_library(${TARGET_LIB} STATIC)
+
+# Specify the output directory for the .a file (project root directory)
+set_target_properties(${TARGET_LIB} PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}"
+)
+
+# Include directories
+include_directories(
+    src
+    src/intraFont
+    src/libpspmath
+    src/adhoc
+)
+
+# Define the source files
+set(SOURCE_DIR src)
+set(SFONT_SOURCES ${SOURCE_DIR}/sfont.c)
+set(PSPMATH_SOURCES
+    ${SOURCE_DIR}/libpspmath/printMatrixFloat.c
+    ${SOURCE_DIR}/libpspmath/vfpu_srand.c
+    ${SOURCE_DIR}/libpspmath/vfpu_randf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_rand_8888.c
+    ${SOURCE_DIR}/libpspmath/vfpu_identity_matrix.c
+    ${SOURCE_DIR}/libpspmath/vfpu_translate_matrix.c
+    ${SOURCE_DIR}/libpspmath/vfpu_perspective_matrix.c
+    ${SOURCE_DIR}/libpspmath/vfpu_ortho_matrix.c
+    ${SOURCE_DIR}/libpspmath/vfpu_sinf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_cosf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_tanf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_asinf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_acosf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_atanf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_sinhf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_coshf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_tanhf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_sincos.c
+    ${SOURCE_DIR}/libpspmath/vfpu_expf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_logf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_fabsf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_sqrtf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_powf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_fmodf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_fminf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_fmaxf.c
+    ${SOURCE_DIR}/libpspmath/vfpu_ease_in_out.c
+    ${SOURCE_DIR}/libpspmath/vfpu_normalize_vector.c
+    ${SOURCE_DIR}/libpspmath/vfpu_zero_vector.c
+    ${SOURCE_DIR}/libpspmath/vfpu_scale_vector.c
+    ${SOURCE_DIR}/libpspmath/vfpu_add_vector.c
+    ${SOURCE_DIR}/libpspmath/vfpu_envmap_matrix.c
+    ${SOURCE_DIR}/libpspmath/vfpu_sphere_to_cartesian.c
+    ${SOURCE_DIR}/libpspmath/vfpu_quaternion_identity.c
+    ${SOURCE_DIR}/libpspmath/vfpu_quaternion_copy.c
+    ${SOURCE_DIR}/libpspmath/vfpu_quaternion_multiply.c
+    ${SOURCE_DIR}/libpspmath/vfpu_quaternion_normalize.c
+    ${SOURCE_DIR}/libpspmath/vfpu_quaternion_exp.c
+    ${SOURCE_DIR}/libpspmath/vfpu_quaternion_ln.c
+    ${SOURCE_DIR}/libpspmath/vfpu_quaternion_sample_linear.c
+    ${SOURCE_DIR}/libpspmath/vfpu_quaternion_from_euler.c
+    ${SOURCE_DIR}/libpspmath/vfpu_quaternion_to_matrix.c
+    ${SOURCE_DIR}/libpspmath/vfpu_quaternion_sample_hermite.c
+    ${SOURCE_DIR}/libpspmath/vfpu_quaternion_hermite_tangent.c
+)
+
+set(LIB_SOURCES
+    ${SOURCE_DIR}/oslib.c
+    ${SOURCE_DIR}/vfpu.c
+    ${SOURCE_DIR}/drawing.c
+    ${SOURCE_DIR}/image.c
+    ${SOURCE_DIR}/palette.c
+    ${SOURCE_DIR}/shape.c
+    ${SOURCE_DIR}/map.c
+    ${SOURCE_DIR}/messagebox.c
+    ${SOURCE_DIR}/oslHandleLoadNoFailError.c
+    ${SOURCE_DIR}/keys.c
+    ${SOURCE_DIR}/text.c
+    ${SOURCE_DIR}/vram_mgr.c
+    ${SOURCE_DIR}/audio/audio.c
+    ${SOURCE_DIR}/audio/bgm.c
+    ${SOURCE_DIR}/audio/mod.c
+    ${SOURCE_DIR}/audio/media.c
+    ${SOURCE_DIR}/usb.c
+    ${SOURCE_DIR}/dialog.c
+    ${SOURCE_DIR}/osk.c
+    ${SOURCE_DIR}/saveload.c
+    ${SOURCE_DIR}/net.c
+    ${SOURCE_DIR}/browser.c
+    ${SOURCE_DIR}/adhoc/pspadhoc.c
+    ${SOURCE_DIR}/vfile/VirtualFile.c
+    ${SOURCE_DIR}/vfile/vfsFile.c
+    ${SOURCE_DIR}/image/oslConvertImageTo.c
+    ${SOURCE_DIR}/image/oslSetImagePixel.c
+    ${SOURCE_DIR}/image/oslGetImagePixel.c
+    ${SOURCE_DIR}/image/oslDrawImage.c
+    ${SOURCE_DIR}/image/oslDrawImageSimple.c
+    ${SOURCE_DIR}/image/oslDrawImageBig.c
+    ${SOURCE_DIR}/image/oslLockImage.c
+    ${SOURCE_DIR}/image/oslMoveImageTo.c
+    ${SOURCE_DIR}/image/oslSwizzleImage.c
+    ${SOURCE_DIR}/image/oslUnswizzleImage.c
+    ${SOURCE_DIR}/image/oslSetDrawBuffer.c
+    ${SOURCE_DIR}/image/oslResetImageProperties.c
+    ${SOURCE_DIR}/image/oslScaleImage.c
+    ${SOURCE_DIR}/gif/dev2gif.c ${SOURCE_DIR}/gif/dgif_lib.c ${SOURCE_DIR}/gif/egif_lib.c
+    ${SOURCE_DIR}/gif/gif_err.c ${SOURCE_DIR}/gif/gifalloc.c ${SOURCE_DIR}/gif/quantize.c
+    ${SOURCE_DIR}/Special/oslLoadImageFilePNG.c
+    ${SOURCE_DIR}/Special/oslWriteImageFilePNG.c
+    ${SOURCE_DIR}/Special/oslLoadImageFileJPG.c
+    ${SOURCE_DIR}/Special/oslLoadImageFileGIF.c
+    ${SOURCE_DIR}/Special/oslLoadImageFile.c
+    ${SOURCE_DIR}/Special/oslWriteImageFile.c
+    ${SOURCE_DIR}/splash/oslShowSplashScreen1.c
+    ${SOURCE_DIR}/splash/oslShowSplashScreen2.c
+    ${SOURCE_DIR}/mem/oslGetRamStatus.c
+    ${SOURCE_DIR}/intraFont/intraFont.c
+    ${SOURCE_DIR}/intraFont/libccc.c
+    ${SOURCE_DIR}/stub.S
+)
+
+# Specify that stub.S is an assembly file
+set_source_files_properties(${SOURCE_DIR}/stub.S PROPERTIES LANGUAGE ASM)
+
+# Add sources to the target
+target_sources(${TARGET_LIB} PRIVATE ${SFONT_SOURCES} ${PSPMATH_SOURCES} ${LIB_SOURCES})
+
+# Define preprocessor defines
+target_compile_definitions(${TARGET_LIB} PRIVATE _DEBUG PSP)
+
+# Set the C flags
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -G0 -ggdb -Wall -DHAVE_AV_CONFIG_H -fno-strict-aliasing -fverbose-asm")
+
+# Set the C++ flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS} -fno-exceptions -fno-rtti")
+
+# Linker flags
+target_link_libraries(${TARGET_LIB}
+    -lpspsdk
+    -lpspctrl -lpsphprm
+    -lpspumd
+    -lpsprtc
+    -lpspgu -lpspgum
+    -lpspaudiolib
+    -lpspaudio -lpspaudiocodec
+    -lpsppower
+    -lpspusb -lpspusbstor
+    -lpsputility
+    -lpspssl -lpsphttp -lpspwlan
+    -lpspnet_adhoc -lpspnet_adhocctl -lpspnet_adhocmatching
+    -lpng -ljpeg -lz -lm
+)
+
+# Installation instructions
+install(TARGETS ${TARGET_LIB} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+install(DIRECTORY src/ DESTINATION ${CMAKE_INSTALL_PREFIX}/include/oslib FILES_MATCHING PATTERN "*.h")

--- a/Platform/PSP.cmake
+++ b/Platform/PSP.cmake
@@ -1,0 +1,32 @@
+# Platform/PSP.cmake
+# Configuration file for the PSP platform
+
+# Set the C and C++ compilers
+set(CMAKE_C_COMPILER psp-gcc)
+set(CMAKE_CXX_COMPILER psp-g++)
+
+# Set the assembler
+set(CMAKE_ASM_COMPILER psp-gcc)
+
+# Set the PSP architecture (MIPS32R2)
+set(CMAKE_SYSTEM_PROCESSOR mips)
+
+# Set the system name
+set(CMAKE_SYSTEM_NAME PSP)
+
+# Set the path to the PSP SDK includes and libraries
+include_directories(
+    $ENV{PSPDEV}/psp/include
+    $ENV{PSPDEV}/psp/sdk/include
+)
+link_directories(
+    $ENV{PSPDEV}/psp/lib
+    $ENV{PSPDEV}/psp/sdk/lib
+)
+
+# Specify that we're cross-compiling
+set(CMAKE_CROSSCOMPILING TRUE)
+
+# Set common PSP compile flags
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -G0 -Wall -D__PSP__ -DPSP -O2")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -G0 -Wall -D__PSP__ -DPSP -O2")


### PR DESCRIPTION
### **Summary**
This PR finalizes and refines the CMake-based build system for the OSLib project, ensuring a reliable and maintainable setup tailored for PSP development. Key configurations and enhancements have been implemented to streamline the build process and improve cross-compilation support.

### **Key Changes**
- **CMake Configuration**: 
  - Introduced a modular CMake setup, defining the `libosl.a` static library as the main output.
  - All relevant source files and directories are correctly included, with specific handling for assembly files.
  - Ensured that the `.a` file is outputted directly in the project root directory.
  
- **PSP Toolchain Integration**:
  - Created and utilized a `Platform/PSP.cmake` file to manage PSP-specific toolchain settings.
  - Configured the C and C++ compilers, assembler, and common PSP compilation flags within the platform file.
  
- **Build Process**:
  - Established a straightforward build process involving `psp-cmake ..` and `make` commands.
  - Verified successful builds with the correct output directory and file naming conventions.

### **Improvements**:
- **Cross-Compilation Support**: Enhanced the PSP toolchain integration for better cross-compilation, centralizing PSP-specific configurations.
- **Maintainability**: The project is now easier to maintain, with a clear separation of platform-specific configurations and project-specific build logic.

### **Testing and Validation**:
- Successfully tested the build process, confirming that the `libosl.a` static library is correctly generated in the root directory.
- Verified that all source files are compiled with the appropriate flags, and the output is as expected.